### PR TITLE
CHEF-25072 - decommission - add_archive_note_to_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This repository has been archived and will no longer receive updates.  
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).  
+If you are a Chef customer and need support for this repository, please contact your Chef account team.
+—
+
 # Test InSpec Profile - Chef Node Passthru
 
 This is an Chef InSpec Profile used in testing the Audit Cookbook. It is used in the audit cookbook's Kitchen file to detect the presence of an Input, `chef_node`. The Audit Cookbook optionally passes this Input thru based on a Chef Infra attribute.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# Archived Repository
+
 This repository has been archived and will no longer receive updates.  
 It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).  
 If you are a Chef customer and need support for this repository, please contact your Chef account team.
-—
+
 
 # Test InSpec Profile - Chef Node Passthru
 


### PR DESCRIPTION
This PR adds an archive notice to the top of the README.md to indicate that this repository is no longer maintained and has been archived as part of the Repository Standardization Initiative.